### PR TITLE
Cloning different datasets

### DIFF
--- a/backend/routes/views.py
+++ b/backend/routes/views.py
@@ -138,6 +138,7 @@ def clone():
     update_dashboard_uuids(charts, f'{ZIP_DIR}/{dashboard_export_name}/charts/', dashboard_filename)
     update_chart_uuids(charts, f'{ZIP_DIR}/{dashboard_export_name}/')
     update_dataset_uuids(charts, f'{ZIP_DIR}/{dashboard_export_name}/')
+
     import_new_dashboard(request_handler, dashboard_export_name)
 
     delete_zip(f"{ZIP_DIR}/")

--- a/backend/routes/views.py
+++ b/backend/routes/views.py
@@ -120,23 +120,23 @@ def clone2():
     FILE_DIR = os.path.dirname(os.path.abspath(__file__))
     PARENT_DIR = os.path.join(FILE_DIR, os.pardir)
     GRANDPARENT_DIR = os.path.abspath(os.path.join(PARENT_DIR, os.pardir))
-    dir_of_interest = os.path.join(GRANDPARENT_DIR, 'backend/zip')
+    ZIP_DIR = os.path.join(GRANDPARENT_DIR, 'backend/zip')
 
     request_handler = APIRequestHandler(SUPERSET_INSTANCE_URL, SUPERSET_USERNAME, SUPERSET_PASSWORD)
 
     extracted_folder_name = export_one_dashboard(request_handler, dashboard_id)
-    update_dataset(request_handler, extracted_folder_name, dataset_id)
-    breakpoint()
+    update_data(request_handler, ZIP_DIR, extracted_folder_name, dataset_id)
+
     dashboard_filename = get_dashboard_filename(dashboard_id, dashboard_old_name,
-                                                dir_of_interest, extracted_folder_name)
+                                                ZIP_DIR, extracted_folder_name)
 
     set_new_details(dashboard_filename, [("dashboard_title", dashboard_new_name), ("uuid", create_id())])
     change_chart_details(charts, extracted_folder_name)
-    update_dashboard_uuids(charts, f'{dir_of_interest}/{extracted_folder_name}/charts/', dashboard_filename)
+    update_dashboard_uuids(charts, f'{ZIP_DIR}/{extracted_folder_name}/charts/', dashboard_filename)
 
     import_new_dashboard(request_handler, extracted_folder_name)
 
-    #delete_zip(f"{dir_of_interest}/")
+    delete_zip(f"{ZIP_DIR}/")
     return "Cloning Successful"
 
 

--- a/backend/routes/views.py
+++ b/backend/routes/views.py
@@ -140,5 +140,5 @@ def clone():
     update_dataset_uuids(charts, f'{ZIP_DIR}/{dashboard_export_name}/')
     import_new_dashboard(request_handler, dashboard_export_name)
 
-    #delete_zip(f"{ZIP_DIR}/")
+    delete_zip(f"{ZIP_DIR}/")
     return "Cloning Successful"

--- a/backend/routes/views.py
+++ b/backend/routes/views.py
@@ -101,8 +101,7 @@ def clone2():
            "dashboard_id":
            "dashboard_old_name":
            "dashboard_new_name":
-           "dataset": dataset_name
-           "database": database_name
+           "dataset_id":
            "charts": [
                         [
                         chart_id
@@ -117,7 +116,6 @@ def clone2():
     dashboard_new_name = request.json.get("dashboard_new_name")
     charts = request.json.get("charts")
     dataset_id = request.json.get("dataset_id")
-    database_id = request.json.get("database_id")
 
     FILE_DIR = os.path.dirname(os.path.abspath(__file__))
     PARENT_DIR = os.path.join(FILE_DIR, os.pardir)
@@ -128,7 +126,6 @@ def clone2():
 
     extracted_folder_name = export_one_dashboard(request_handler, dashboard_id)
     update_dataset(request_handler, extracted_folder_name, dataset_id)
-    update_database(request_handler, extracted_folder_name, database_id)
     breakpoint()
     dashboard_filename = get_dashboard_filename(dashboard_id, dashboard_old_name,
                                                 dir_of_interest, extracted_folder_name)

--- a/backend/routes/views.py
+++ b/backend/routes/views.py
@@ -107,6 +107,8 @@ def clone():
                         chart_id
                         chart_old_name
                         chart_new_name
+                        "chart_new_dataset": "covid_vaccines",
+                        "database": "examples"
                         ]
                    ]
        }
@@ -124,17 +126,19 @@ def clone():
 
     request_handler = APIRequestHandler(SUPERSET_INSTANCE_URL, SUPERSET_USERNAME, SUPERSET_PASSWORD)
 
-    extracted_folder_name = export_one_dashboard(request_handler, dashboard_id)
-    update_data(request_handler, ZIP_DIR, extracted_folder_name, dataset_id)
+    dashboard_export_name = export_one_dashboard(request_handler, dashboard_id)
+    swap_dataset_and_database(request_handler, ZIP_DIR, dashboard_export_name, dataset_id)
 
     dashboard_filename = get_dashboard_filename(dashboard_id, dashboard_old_name,
-                                                ZIP_DIR, extracted_folder_name)
+                                                ZIP_DIR, dashboard_export_name)
 
     set_new_details(dashboard_filename, [("dashboard_title", dashboard_new_name), ("uuid", create_id())])
-    change_chart_details(charts, extracted_folder_name)
-    update_dashboard_uuids(charts, f'{ZIP_DIR}/{extracted_folder_name}/charts/', dashboard_filename)
+    change_chart_details(charts, dashboard_export_name)
 
-    import_new_dashboard(request_handler, extracted_folder_name)
+    update_dashboard_uuids(charts, f'{ZIP_DIR}/{dashboard_export_name}/charts/', dashboard_filename)
+    update_chart_uuids(charts, f'{ZIP_DIR}/{dashboard_export_name}/')
+    update_dataset_uuids(charts, f'{ZIP_DIR}/{dashboard_export_name}/')
+    import_new_dashboard(request_handler, dashboard_export_name)
 
-    delete_zip(f"{ZIP_DIR}/")
+    #delete_zip(f"{ZIP_DIR}/")
     return "Cloning Successful"

--- a/backend/routes/views.py
+++ b/backend/routes/views.py
@@ -67,7 +67,6 @@ def get_all_datasets():
                 "dataset_name": "name",
                 "database_name": "name"
                 "dataset_id": dataset_id,
-                "database_id": database_id
             },
             {
                 <More datasets>
@@ -82,13 +81,11 @@ def get_all_datasets():
         dataset_name = dataset[0]
         db_name = dataset[1]
         dataset_id = dataset[2]
-        db_id = dataset[3]
 
         curr_dataset_info = {
             "dataset_name": dataset_name,
             "database_name": db_name,
             "dataset_id": dataset_id,
-            "database_id": db_id
         }
 
         dataset_list.append(curr_dataset_info)
@@ -119,8 +116,8 @@ def clone2():
     dashboard_old_name = request.json.get("dashboard_old_name")
     dashboard_new_name = request.json.get("dashboard_new_name")
     charts = request.json.get("charts")
-    dataset_name = request.json.get("dataset")
-    database_name = request.json.get("database")
+    dataset_id = request.json.get("dataset_id")
+    database_id = request.json.get("database_id")
 
     FILE_DIR = os.path.dirname(os.path.abspath(__file__))
     PARENT_DIR = os.path.join(FILE_DIR, os.pardir)
@@ -129,9 +126,10 @@ def clone2():
 
     request_handler = APIRequestHandler(SUPERSET_INSTANCE_URL, SUPERSET_USERNAME, SUPERSET_PASSWORD)
 
-    #extracted_folder_name = export_one_dashboard(request_handler, dashboard_id)
-    extracted_folder_name = "temp"
-    update_dataset(request_handler, extracted_folder_name, dataset_name, database_name)
+    extracted_folder_name = export_one_dashboard(request_handler, dashboard_id)
+    update_dataset(request_handler, extracted_folder_name, dataset_id)
+    update_database(request_handler, extracted_folder_name, database_id)
+    breakpoint()
     dashboard_filename = get_dashboard_filename(dashboard_id, dashboard_old_name,
                                                 dir_of_interest, extracted_folder_name)
 
@@ -153,8 +151,6 @@ def clone():
            "dashboard_id":
            "dashboard_old_name":
            "dashboard_new_name":
-           "dataset_id"
-           "database_id"
            "charts": [
                         [
                         chart_id

--- a/backend/routes/views.py
+++ b/backend/routes/views.py
@@ -93,8 +93,8 @@ def get_all_datasets():
     return json.dumps(dataset_list)
 
 
-@views.route('/clone2', methods=['POST'])
-def clone2():
+@views.route('/clone', methods=['POST'])
+def clone():
     """
     Expected Return Format
        {
@@ -137,49 +137,4 @@ def clone2():
     import_new_dashboard(request_handler, extracted_folder_name)
 
     delete_zip(f"{ZIP_DIR}/")
-    return "Cloning Successful"
-
-
-@views.route('/clone', methods=['POST'])
-def clone():
-    """
-    Expected Return Format
-       {
-           "dashboard_id":
-           "dashboard_old_name":
-           "dashboard_new_name":
-           "charts": [
-                        [
-                        chart_id
-                        chart_old_name
-                        # chart_new_name
-                        chart_new_dataset
-                        database
-                        ]
-                   ]
-       }
-    """
-    dashboard_id = request.json.get("dashboard_id")
-    dashboard_old_name = request.json.get("dashboard_old_name")
-    dashboard_new_name = request.json.get("dashboard_new_name")
-    charts = request.json.get("charts")
-
-    FILE_DIR = os.path.dirname(os.path.abspath(__file__))
-    PARENT_DIR = os.path.join(FILE_DIR, os.pardir) 
-    GRANDPARENT_DIR = os.path.abspath(os.path.join(PARENT_DIR, os.pardir))
-    dir_of_interest = os.path.join(GRANDPARENT_DIR, 'backend/zip')
-
-    request_handler = APIRequestHandler(SUPERSET_INSTANCE_URL, SUPERSET_USERNAME, SUPERSET_PASSWORD)
-
-    extracted_folder_name = export_one_dashboard(request_handler, dashboard_id)
-    dashboard_filename = get_dashboard_filename(dashboard_id, dashboard_old_name,
-                                                dir_of_interest, extracted_folder_name)
-
-    set_new_details(dashboard_filename, [("dashboard_title", dashboard_new_name), ("uuid", create_id())])
-    change_chart_details(charts, extracted_folder_name)
-    update_dashboard_uuids(charts, f'{dir_of_interest}/{extracted_folder_name}/charts/', dashboard_filename)
-
-    import_new_dashboard(request_handler, extracted_folder_name)
-
-    #delete_zip(f"{dir_of_interest}/")
     return "Cloning Successful"

--- a/backend/utils/api_helpers.py
+++ b/backend/utils/api_helpers.py
@@ -56,7 +56,8 @@ def get_datasets(request_handler):
 
     parsed_datasets = []
     for dataset in datasets.get("result"):
-        parsed_datasets.append((dataset["table_name"], dataset["database"]["database_name"]))
+        parsed_datasets.append((dataset["table_name"], dataset["database"]["database_name"],
+                                dataset["id"], dataset["database"]["id"]))
     return parsed_datasets
 
 
@@ -82,6 +83,27 @@ def export_one_dashboard(request_handler, dashboard_id):
     # 32 corresponds to len("dashboard_export_) + 15 (15 numbers at the end) to get name of extracted folder
     # make this dynamic, hard coded for now
     return myzip.namelist()[0][:32]
+
+
+def update_dataset(request_handler, extracted_folder_name, dataset_name, database_name):
+    """
+    Updates the database and dataset folders within extracted_folder_name
+    """
+    export_database_endpoint = f"api/v1/dataset/export/?q=[12]"
+    breakpoint()
+    export_response = request_handler.get_request(export_database_endpoint)
+    breakpoint()
+    local_path = "zip/all_datasets.zip"
+    with open(local_path, "wb") as f:
+        f.write(export_response.content)
+
+    # extract the folder out of the zip file
+    with zipfile.ZipFile(local_path) as myzip:
+        myzip.extractall(path='./zip')
+    breakpoint()
+    # 32 corresponds to len("dashboard_export_) + 15 (15 numbers at the end) to get name of extracted folder
+    # make this dynamic, hard coded for now
+    return None
 
 
 def get_dashboard_filename(dashboard_id, dashboard_old_name, dir_of_interest, extracted_folder_name):

--- a/backend/utils/api_helpers.py
+++ b/backend/utils/api_helpers.py
@@ -56,8 +56,7 @@ def get_datasets(request_handler):
 
     parsed_datasets = []
     for dataset in datasets.get("result"):
-        parsed_datasets.append((dataset["table_name"], dataset["database"]["database_name"],
-                                dataset["id"], dataset["database"]["id"]))
+        parsed_datasets.append((dataset["table_name"], dataset["database"]["database_name"], dataset["id"]))
     return parsed_datasets
 
 
@@ -85,24 +84,37 @@ def export_one_dashboard(request_handler, dashboard_id):
     return myzip.namelist()[0][:32]
 
 
-def update_dataset(request_handler, extracted_folder_name, dataset_name, database_name):
+def update_dataset(request_handler, extracted_folder_name, dataset_id):
     """
-    Updates the database and dataset folders within extracted_folder_name
+    Updates the dataset folders within extracted_folder_name
     """
-    export_database_endpoint = f"api/v1/dataset/export/?q=[12]"
-    breakpoint()
-    export_response = request_handler.get_request(export_database_endpoint)
-    breakpoint()
-    local_path = "zip/all_datasets.zip"
+    export_dataset_endpoint = f'api/v1/dataset/export/?q=[{dataset_id}]'
+    export_response = request_handler.get_request(export_dataset_endpoint)
+    local_path = "zip/dataset1.zip"
     with open(local_path, "wb") as f:
         f.write(export_response.content)
 
     # extract the folder out of the zip file
     with zipfile.ZipFile(local_path) as myzip:
         myzip.extractall(path='./zip')
-    breakpoint()
-    # 32 corresponds to len("dashboard_export_) + 15 (15 numbers at the end) to get name of extracted folder
-    # make this dynamic, hard coded for now
+
+    return None
+
+
+def update_database(request_handler, extracted_folder_name, database_id):
+    """
+    Updates the database folders within extracted_folder_name
+    """
+    export_database_endpoint = f'api/v1/database/export/?q=[{database_id}]'
+    export_response = request_handler.get_request(export_database_endpoint)
+    local_path = "zip/database1.zip"
+    with open(local_path, "wb") as f:
+        f.write(export_response.content)
+
+    # extract the folder out of the zip file
+    with zipfile.ZipFile(local_path) as myzip:
+        myzip.extractall(path='./zip')
+
     return None
 
 

--- a/backend/utils/api_helpers.py
+++ b/backend/utils/api_helpers.py
@@ -103,7 +103,7 @@ def update_data(request_handler, zip_dir, dashboard_export, dataset_id):
 
     _replace_subfolder(zip_dir, dataset_export, dashboard_export, 'databases')
     _replace_subfolder(zip_dir, dataset_export, dashboard_export, 'datasets')
-    breakpoint()
+
     return dataset_export
 
 

--- a/backend/utils/api_helpers.py
+++ b/backend/utils/api_helpers.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 import zipfile
 import yaml
@@ -71,7 +72,7 @@ def export_one_dashboard(request_handler, dashboard_id):
     export_dashboard_endpoint = f'{EXPORT_ENDPOINT}?q=[{dashboard_id}]'
     export_response = request_handler.get_request(export_dashboard_endpoint)
 
-    local_path = "zip/exported_one_dashboard.zip"
+    local_path = "zip/dashboard.zip"
     with open(local_path, "wb") as f:
         f.write(export_response.content)
 
@@ -79,18 +80,18 @@ def export_one_dashboard(request_handler, dashboard_id):
     with zipfile.ZipFile(local_path) as myzip:
         myzip.extractall(path='./zip')
 
-    # 32 corresponds to len("dashboard_export_) + 15 (15 numbers at the end) to get name of extracted folder
-    # make this dynamic, hard coded for now
-    return myzip.namelist()[0][:32]
+    dashboard_export_name = myzip.namelist()[0].split('/', 1)[0]
+
+    return dashboard_export_name
 
 
-def update_dataset(request_handler, extracted_folder_name, dataset_id):
+def update_data(request_handler, zip_dir, dashboard_export, dataset_id):
     """
     Updates the dataset folders within extracted_folder_name
     """
     export_dataset_endpoint = f'api/v1/dataset/export/?q=[{dataset_id}]'
     export_response = request_handler.get_request(export_dataset_endpoint)
-    local_path = "zip/dataset1.zip"
+    local_path = "zip/dataset.zip"
     with open(local_path, "wb") as f:
         f.write(export_response.content)
 
@@ -98,38 +99,26 @@ def update_dataset(request_handler, extracted_folder_name, dataset_id):
     with zipfile.ZipFile(local_path) as myzip:
         myzip.extractall(path='./zip')
 
-    return None
+    dataset_export = myzip.namelist()[0].split('/', 1)[0]
+
+    _replace_subfolder(zip_dir, dataset_export, dashboard_export, 'databases')
+    _replace_subfolder(zip_dir, dataset_export, dashboard_export, 'datasets')
+    breakpoint()
+    return dataset_export
 
 
-def update_database(request_handler, extracted_folder_name, database_id):
-    """
-    Updates the database folders within extracted_folder_name
-    """
-    export_database_endpoint = f'api/v1/database/export/?q=[{database_id}]'
-    export_response = request_handler.get_request(export_database_endpoint)
-    local_path = "zip/database1.zip"
-    with open(local_path, "wb") as f:
-        f.write(export_response.content)
-
-    # extract the folder out of the zip file
-    with zipfile.ZipFile(local_path) as myzip:
-        myzip.extractall(path='./zip')
-
-    return None
-
-
-def get_dashboard_filename(dashboard_id, dashboard_old_name, dir_of_interest, extracted_folder_name):
+def get_dashboard_filename(dashboard_id, dashboard_old_name, zip_dir, extracted_folder_name):
     """
     Get the full path to the dashboard filename
 
     @param dashboard_id: The dashboard_id of the dashboard
     @param dashboard_old_name: The original name of the dashboard
-    @param dir_of_interest: The full path to the zip file
+    @param zip_dir: The full path to the zip file
     @param extracted_folder_name: The folder within the zip file created from export_one_dashboard()
     @return: The full path of the dashboard file
     """
     dashboard_old_name_parsed = dashboard_old_name.replace(" ", "_")
-    d1 = f'{dir_of_interest}/{extracted_folder_name}/dashboards/'
+    d1 = f'{zip_dir}/{extracted_folder_name}/dashboards/'
     d2 = f'{dashboard_old_name_parsed}_{dashboard_id}.yaml'
 
     dashboard_filename = d1 + d2
@@ -182,7 +171,7 @@ def change_chart_details(charts, extracted_folder_name):
 
 def update_dashboard_uuids(charts, charts_dir, dashboard_filepath):
     """
-    Update the unique ids of all charts to in dashboard metadata
+    Update the unique ids of all charts in dashboard metadata
 
     @param charts: A list of all charts containing [chart_id, chart_old_name]
     @param charts_dir: The path to the directory containing all charts
@@ -258,6 +247,17 @@ def delete_zip(path):
 
     except OSError:
         print("Error occurred while deleting file")
+
+
+def _replace_subfolder(filepath, source, destination, subfolder_name):
+    source_subfolder = os.path.join(source, subfolder_name)
+    destination_subfolder = os.path.join(destination, subfolder_name)
+
+    # Remove the existing destination subfolder
+    if os.path.exists(f'{filepath}/{destination_subfolder}'):
+        shutil.rmtree(f'{filepath}/{destination_subfolder}')
+
+    shutil.copytree(f'{filepath}/{source_subfolder}', f'{filepath}/{destination_subfolder}')
 
 
 def _get_dataset_uuid(filename):


### PR DESCRIPTION
Allows for the cloning of different datasets. I.E. if we had a covid_vaccines_2 with only US data, we could make a clone with that data instead of using the default covid_vaccines dataset that already existed for the Covid Vaccines dashboard.